### PR TITLE
Updating packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,37 +24,37 @@
   "author": "Mike Kornelson <mike@durbn.net>",
   "license": "MIT",
   "devDependencies": {
-    "babel-core": "^6.24.1",
-    "babel-loader": "^6.4.1",
+    "babel-core": "^6.25.0",
+    "babel-loader": "^7.1.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-1": "^6.24.1",
-    "chai": "^3.5.0",
-    "enzyme": "^2.8.2",
+    "chai": "^4.0.2",
+    "enzyme": "^2.9.0",
     "jsdom": "^9.12.0",
     "jsdom-global": "^2.1.1",
-    "mocha": "^3.2.0",
-    "react": "^15.5.4",
-    "react-addons-test-utils": "^15.5.1",
-    "react-dom": "^15.5.4",
+    "mocha": "^3.4.2",
+    "react": "^15.6.1",
+    "react-addons-test-utils": "^15.6.0",
+    "react-dom": "^15.6.1",
     "react-scripts": "^0.9.5",
     "react-test-renderer": "^15.6.1",
-    "semantic-ui-react": "^0.68.0",
+    "semantic-ui-react": "^0.69.0",
     "sinon": "^2.3.5",
     "webpack": "^2.4.1",
-    "webpack-node-externals": "^1.5.4"
+    "webpack-node-externals": "^1.6.0"
   },
   "peerDependencies": {
     "react": "^15.5.0",
-    "semantic-ui-react": "^0.68.0"
+    "semantic-ui-react": "^0.69.0"
   },
   "dependencies": {
     "accounting": "^0.4.1",
     "debug": "^2.6.8",
-    "inputmask": "^3.3.5",
+    "inputmask": "^3.3.7",
     "js-money": "^0.6.3",
     "lodash": "^4.17.4",
-    "prop-types": "^15.5.8",
+    "prop-types": "^15.5.10",
     "tproptypes": "^0.1.6"
   }
 }


### PR DESCRIPTION
babel-loader        ^6.4.1  →   ^7.1.0 
 chai                ^3.5.0  →   ^4.0.2 
 semantic-ui-react  ^0.68.0  →  ^0.69.0 
 inputmask                 ^3.3.5  →    ^3.3.7 
 prop-types               ^15.5.8  →  ^15.5.10 
 babel-core               ^6.24.1  →   ^6.25.0 
 enzyme                    ^2.8.2  →    ^2.9.0 
 mocha                     ^3.2.0  →    ^3.4.2 
 react                    ^15.5.4  →   ^15.6.1 
 react-addons-test-utils  ^15.5.1  →   ^15.6.0 
 react-dom                ^15.5.4  →   ^15.6.1 
 webpack-node-externals    ^1.5.4  →    ^1.6.0